### PR TITLE
Fixed controller reference deprecation

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 prg_control:
   path: /prg_resolve/
   defaults:
-    _controller: BFPrgBundle:Default:resolve
+    _controller: 'BurdaForward\BFPrgBundle\Controller\DefaultController::resolveAction'
   methods: [POST]


### PR DESCRIPTION
Fixed 'Referencing controllers with BFPrgBundle:Default:resolve is deprecated since Symfony 4.1' issue