### PR TITLE
Get rid of using container directly

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,13 +1,12 @@
 services:
     prg_bundle:
         class: BurdaForward\BFPrgBundle\Service\PrgService
-        arguments: ['@service_container']
 
     prg_bundle.twig.prg_link:
         class: BurdaForward\BFPrgBundle\Twig\Extension\Prg
         tags:
             - { name: twig.extension }
-        arguments: ['@service_container']
+        arguments: ['@twig']
 
     BurdaForward\BFPrgBundle\Controller\DefaultController:
         autowire: true

--- a/Twig/Extension/Prg.php
+++ b/Twig/Extension/Prg.php
@@ -3,7 +3,6 @@
 namespace BurdaForward\BFPrgBundle\Twig\Extension;
 
 use BurdaForward\BFPrgBundle\Service\PrgService;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -22,12 +21,11 @@ class Prg extends AbstractExtension
     /**
      * Prg constructor.
      *
-     * @param ContainerInterface $container
-     * @throws \Exception
+     * @param Environment $twigEnvironment
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(Environment $twigEnvironment)
     {
-        $this->twigEnvironment = $container->get('twig');
+        $this->twigEnvironment = $twigEnvironment;
     }
 
     /**


### PR DESCRIPTION
Got rid of using container directly in any service. Original reason was: since symfony/twig-bundle 5.2: Accessing the "twig" service directly from the container is deprecated.